### PR TITLE
Model based geometry eps

### DIFF
--- a/patato/__init__.py
+++ b/patato/__init__.py
@@ -62,3 +62,5 @@ for e in __all_exports:
     e.__module__ = __name__
 
 __all__ = [e.__name__ for e in __all_exports] + ["core", "io", "recon", "unmixing", "processing", "utils", "data"]
+
+print("HELLO")

--- a/patato/__init__.py
+++ b/patato/__init__.py
@@ -63,4 +63,3 @@ for e in __all_exports:
 
 __all__ = [e.__name__ for e in __all_exports] + ["core", "io", "recon", "unmixing", "processing", "utils", "data"]
 
-print("HELLO")

--- a/patato/core/image_structures/image_sequence.py
+++ b/patato/core/image_structures/image_sequence.py
@@ -144,7 +144,6 @@ class DataSequence(ProcessingResult, ABC):
                mask_roi=True,
                cmap=None, scale_kwargs=None, return_scalebar_dimension=False, scalebar=True, transpose=False, log=False,
                **kwargs):
-        print('This is being graphed.')
         if scale_kwargs is None:
             scale_kwargs = {}
 

--- a/patato/core/image_structures/image_sequence.py
+++ b/patato/core/image_structures/image_sequence.py
@@ -144,6 +144,7 @@ class DataSequence(ProcessingResult, ABC):
                mask_roi=True,
                cmap=None, scale_kwargs=None, return_scalebar_dimension=False, scalebar=True, transpose=False, log=False,
                **kwargs):
+        print('This is being graphed.')
         if scale_kwargs is None:
             scale_kwargs = {}
 

--- a/patato/recon/backprojection_reference.py
+++ b/patato/recon/backprojection_reference.py
@@ -44,7 +44,7 @@ class ReferenceBackprojection(ReconstructionAlgorithm):
         -------
 
         """
-
+        print(f"c = {speed_of_sound}")
         # Get parameters:
         dl = speed_of_sound / fs
 

--- a/patato/recon/backprojection_reference.py
+++ b/patato/recon/backprojection_reference.py
@@ -44,7 +44,6 @@ class ReferenceBackprojection(ReconstructionAlgorithm):
         -------
 
         """
-        print(f"c = {speed_of_sound}")
         # Get parameters:
         dl = speed_of_sound / fs
 

--- a/patato/recon/model_based/model_based.py
+++ b/patato/recon/model_based/model_based.py
@@ -190,8 +190,9 @@ class ModelBasedReconstruction(ReconstructionAlgorithm):
             # identify x and y:
             detectors = kwargs_model["geometry"]
             indices = []
+            eps = 1e-10
             for i in range(3):
-                if np.any(kwargs_model["geometry"][:, i] != 0.):
+                if np.any(np.absolute(kwargs_model["geometry"][:, i]) > eps):
                     indices.append(i)
             self._indices = indices
 


### PR DESCRIPTION
When finding the plane in which the detectors are based, the code must find the non-zero columns for the sensor positions. However, it counts values ~1e-17 (which arises from recentring the detectors by subtracting the mean) as non-zero. A limit of eps = 1e-10 has been implemented so the positions do not have to be exactly 0.