### PR TITLE
Inconsistency in timestamp roundtrip for ithera files

### DIFF
--- a/patato/io/hdf/hdf5_interface.py
+++ b/patato/io/hdf/hdf5_interface.py
@@ -145,8 +145,9 @@ class HDF5Writer(WriterInterface):
         )
 
     def set_scan_times(self, scan_times):
+        # Store in 100 ns ticks (backwards compatibility)
         self.file.create_dataset(
-            HDF5Tags.TIMESTAMP, data=scan_times, compression="gzip"
+            HDF5Tags.TIMESTAMP, data=scan_times * 1e7, compression="gzip"
         )
 
     def set_sensor_geometry(self, sensor_geometry):

--- a/patato/io/ithera/iannotation.py
+++ b/patato/io/ithera/iannotation.py
@@ -81,8 +81,8 @@ class IROIShape(ABC):
         """
         Extract the (x, y, z) coordinates from the pos or size string.
         """
-        roi_coords = re.findall(r"\((.*?)\)", roi_string)[0].split(", ")
-        return [float(c) for c in roi_coords]
+        roi_coords = re.search(r"\((.*?)\)", roi_string).group(1).split(",")
+        return [float(c.strip()) for c in roi_coords]
 
     @property
     def type(self) -> str:

--- a/patato/io/ithera/read_ithera.py
+++ b/patato/io/ithera/read_ithera.py
@@ -407,7 +407,8 @@ class iTheraMSOT(ReaderInterface):
         ).replace(tzinfo=None)
 
     def _get_scan_times(self):
-        return self.scan_attrs["timestamp"]
+        # Convert to seconds, iThera stores timestamps in 100 ns ticks.
+        return self.scan_attrs["timestamp"] * 1e-7
 
     def _get_temperature(self):
         return self.scan_elements["TEMPERATURE"]


### PR DESCRIPTION
Hi again,

I noticed that there seems to be an inconsistency in the timestamp handling for the ithera data. When going _iThera → PAData → HDF5  →  PAData_ the timestamp doesnt stay the same.


### Reproduce:

```
from patato import PAData, iTheraMSOT

# read timestamp from native iThera data
ithera_scanpath = "data/Study_8/Scan_2"
pa_ithera = PAData(iTheraMSOT(ithera_scanpath))
print("iThera timestamps:", ithera_ts:=float(pa_ithera.get_timestamps()[0,0]))

# export to hdf5
hdf5_outscanpath = "data/8_2.hdf5"
pa_ithera.save_hdf5(hdf5_outscanpath)

# load exported hdf5 again and print timestamp
pa_hdf5 = PAData.from_hdf5(hdf5_outscanpath)
print("HDF5 timestamps:", hdf5_ts:=float(pa_hdf5.get_timestamps()[0,0]))
```

THe result is:

```
iThera timestamps: 6.378771922936801e+17
HDF5 timestamps: 63787719229.36801
```

### Explanation
The reason seems to be that PAData.get_timestamps() claims it returns seconds, but iThera reader returns raw ithera timestamps without conversion (100ns ticks). But the HDF5Reader on the other hand scales it by 1e-7. And Exporting simply writes whatever it gets from reader.

### Fix
Have the  iThera reader convert data to seconds. HDF5 Writer converts to 100ns ticks, this way backward compatibility should stay intact.


## Other changes

minor fix in iannotation file parsing for broader compatibility with some older ilabs versions

