### PR TITLE
Require uv >=0.8.7 and clarify tkinter import errors

### DIFF
--- a/patato/convenience_scripts/draw_roi.py
+++ b/patato/convenience_scripts/draw_roi.py
@@ -20,7 +20,12 @@ try:
     )
 except ImportError:
     print(
-        "This seems to be an error in Python 3.13 running on uv (standalone builds of Python). Try to run on Python 3.12."
+        "Failed to import tkinter support for matplotlib. If you are using uv, this "
+        "usually means your uv-managed Python was installed before uv started bundling "
+        "a working tkinter (August 2025, uv >= 0.8.7). Try running "
+        "`uv python upgrade --reinstall` (or `uv self update` followed by "
+        "`uv python install --reinstall`), or use a system/Homebrew Python built with "
+        "tkinter support (e.g. `brew install python-tk@3.12`) instead."
     )
     raise
 

--- a/patato/convenience_scripts/tune_speed_of_sound.py
+++ b/patato/convenience_scripts/tune_speed_of_sound.py
@@ -13,7 +13,21 @@ from ..recon import get_default_recon_preset
 from ..io.json.json_reading import read_reconstruction_preset
 
 import os
-from matplotlib.backends.backend_tkagg import FigureCanvasTkAgg, NavigationToolbar2Tk
+try:
+    from matplotlib.backends.backend_tkagg import (
+        FigureCanvasTkAgg,
+        NavigationToolbar2Tk,
+    )
+except ImportError:
+    print(
+        "Failed to import tkinter support for matplotlib. If you are using uv, this "
+        "usually means your uv-managed Python was installed before uv started bundling "
+        "a working tkinter (August 2025, uv >= 0.8.7). Try running "
+        "`uv python upgrade --reinstall` (or `uv self update` followed by "
+        "`uv python install --reinstall`), or use a system/Homebrew Python built with "
+        "tkinter support (e.g. `brew install python-tk@3.12`) instead."
+    )
+    raise
 
 from importlib.resources import files
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -86,6 +86,12 @@ write_to = "patato/_version.py"
 # Disable building PyPy wheels on all platforms
 skip = "pp*"
 
+[tool.uv]
+# python-build-standalone only started bundling working tkinter/Tcl-Tk support
+# in its August 2025 releases; older uv versions can silently resolve to an
+# interpreter with no _tkinter extension at all, breaking the GUI scripts.
+required-version = ">=0.8.7"
+
 [dependency-groups]
 dev = [
     "ipykernel>=6.29.5",


### PR DESCRIPTION
## Summary
- `python-build-standalone` only started bundling a working tkinter/Tcl-Tk in its August 2025 releases (uv >= 0.8.7). Older cached uv-managed Python installs can silently lack `_tkinter` entirely, which breaks `patato-draw-roi` / `patato-set-speed-of-sound`.
- Added `[tool.uv] required-version = ">=0.8.7"` to `pyproject.toml` so users on an old uv get a clear version error instead of a cryptic `ImportError`.
- Fixed the misleading error message in `draw_roi.py` (blamed "Python 3.13" specifically, which isn't accurate — reproduced the same failure on a stale cached uv-managed 3.12) and added the same guard to `tune_speed_of_sound.py`, which had no guard at all.

## Test plan
- [x] Reproduced the original failure with a stale uv-managed `cpython-3.12.9` (no `_tkinter` in `lib-dynload`).
- [x] Confirmed a freshly-downloaded uv-managed `cpython-3.12.12` includes working tkinter (Tk 9.0) out of the box.
- [x] `uv lock --check` passes with the new `[tool.uv]` section.
- [x] Manually launched both `draw_roi.py` and `tune_speed_of_sound.py` GUIs (via Homebrew Python + `python-tk`) and exercised widget creation, error dialogs, ROI-drawing toggle, dropdowns, and sliders without errors.